### PR TITLE
Fix tap1 form to display in front of buttons

### DIFF
--- a/src/main/java/Pedido/Factura/tap1.java
+++ b/src/main/java/Pedido/Factura/tap1.java
@@ -8,7 +8,7 @@ package Pedido.Factura;
  *
  * @author DAZX
  */
-public class tap1 extends javax.swing.JFrame {
+public class tap1 extends javax.swing.JPanel {
 
     /**
      * Creates new form tap1
@@ -37,7 +37,7 @@ public class tap1 extends javax.swing.JFrame {
         jButton10 = new javax.swing.JButton();
         jButton11 = new javax.swing.JButton();
 
-        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        setLayout(new org.netbeans.lib.awtextra.AbsoluteLayout());
 
         Cubierta1.setLayout(new org.netbeans.lib.awtextra.AbsoluteLayout());
 
@@ -71,6 +71,11 @@ public class tap1 extends javax.swing.JFrame {
         jButton10.setText("Cancelar");
         jButton10.setBorder(null);
         jButton10.setBorderPainted(false);
+        jButton10.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jButton10ActionPerformed(evt);
+            }
+        });
 
         jButton11.setBackground(new java.awt.Color(58, 179, 28));
         jButton11.setForeground(new java.awt.Color(255, 255, 255));
@@ -133,28 +138,7 @@ public class tap1 extends javax.swing.JFrame {
 
         Cubierta1.add(jPanel7, new org.netbeans.lib.awtextra.AbsoluteConstraints(240, 210, 310, 220));
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 800, Short.MAX_VALUE)
-            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(layout.createSequentialGroup()
-                    .addGap(0, 0, Short.MAX_VALUE)
-                    .addComponent(Cubierta1, javax.swing.GroupLayout.PREFERRED_SIZE, 800, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGap(0, 0, Short.MAX_VALUE)))
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 665, Short.MAX_VALUE)
-            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(layout.createSequentialGroup()
-                    .addGap(0, 0, Short.MAX_VALUE)
-                    .addComponent(Cubierta1, javax.swing.GroupLayout.PREFERRED_SIZE, 665, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGap(0, 0, Short.MAX_VALUE)))
-        );
-
-        pack();
+        add(Cubierta1, new org.netbeans.lib.awtextra.AbsoluteConstraints(0, 0, 800, 665));
     }// </editor-fold>//GEN-END:initComponents
 
     private void jComboBox1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBox1ActionPerformed
@@ -165,40 +149,10 @@ public class tap1 extends javax.swing.JFrame {
         // TODO add your handling code here:
     }//GEN-LAST:event_jButton11ActionPerformed
 
-    /**
-     * @param args the command line arguments
-     */
-    public static void main(String args[]) {
-        /* Set the Nimbus look and feel */
-        //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
-        /* If Nimbus (introduced in Java SE 6) is not available, stay with the default look and feel.
-         * For details see http://download.oracle.com/javase/tutorial/uiswing/lookandfeel/plaf.html 
-         */
-        try {
-            for (javax.swing.UIManager.LookAndFeelInfo info : javax.swing.UIManager.getInstalledLookAndFeels()) {
-                if ("Nimbus".equals(info.getName())) {
-                    javax.swing.UIManager.setLookAndFeel(info.getClassName());
-                    break;
-                }
-            }
-        } catch (ClassNotFoundException ex) {
-            java.util.logging.Logger.getLogger(tap1.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
-        } catch (InstantiationException ex) {
-            java.util.logging.Logger.getLogger(tap1.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
-        } catch (IllegalAccessException ex) {
-            java.util.logging.Logger.getLogger(tap1.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
-        } catch (javax.swing.UnsupportedLookAndFeelException ex) {
-            java.util.logging.Logger.getLogger(tap1.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
-        }
-        //</editor-fold>
-
-        /* Create and display the form */
-        java.awt.EventQueue.invokeLater(new Runnable() {
-            public void run() {
-                new tap1().setVisible(true);
-            }
-        });
-    }
+    private void jButton10ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton10ActionPerformed
+        // Close the form
+        this.setVisible(false);
+    }//GEN-LAST:event_jButton10ActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel Cubierta1;

--- a/src/main/java/Secciones/Menu/Carnes.java
+++ b/src/main/java/Secciones/Menu/Carnes.java
@@ -7,6 +7,7 @@ package Secciones.Menu;
 import java.awt.Image;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import Pedido.Factura.tap1;
 
 /**
  *
@@ -170,11 +171,13 @@ public class Carnes extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     private void BotonTerneraActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_BotonTerneraActionPerformed
-        // TODO add your handling code here:
+        tap1 form = new tap1();
+        form.setVisible(true);
     }//GEN-LAST:event_BotonTerneraActionPerformed
 
     private void BotonCerdoActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_BotonCerdoActionPerformed
-        // TODO add your handling code here:
+        tap1 form = new tap1();
+        form.setVisible(true);
     }//GEN-LAST:event_BotonCerdoActionPerformed
 
     private void BotonCorderoActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_BotonCorderoActionPerformed


### PR DESCRIPTION
Add functionality to display the `tap1` form in front of the buttons when the `BotonTernera` and `BotonCerdo` buttons are clicked.

* **src/main/java/Secciones/Menu/Carnes.java**
  - Import `tap1` class.
  - Modify `BotonTerneraActionPerformed` method to create and display `tap1` form.
  - Modify `BotonCerdoActionPerformed` method to create and display `tap1` form.

* **src/main/java/Pedido/Factura/tap1.java**
  - Change `tap1` class to extend `javax.swing.JPanel` instead of `javax.swing.JFrame`.
  - Remove `setDefaultCloseOperation` and set layout to `AbsoluteLayout`.
  - Add action listener to `jButton10` to close the form by setting its visibility to false.

